### PR TITLE
bitflyer API で売り買い判定のベースとなる部分を作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.bundle
+/vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
+gem "activesupport"
+
+# development
+gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    byebug (9.0.6)
+    coderay (1.1.1)
+    concurrent-ruby (1.0.5)
+    i18n (0.8.6)
+    method_source (0.8.2)
+    minitest (5.10.3)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.3)
+      byebug (>= 9.0, < 9.1)
+      pry (~> 0.10)
+    slop (3.6.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  pry-byebug
+
+BUNDLED WITH
+   1.15.1

--- a/lib/array_extension.rb
+++ b/lib/array_extension.rb
@@ -1,0 +1,16 @@
+class Array
+  # average
+  def ave
+    inject(0.0) { |r,i| r += i } / size
+  end
+
+  # variance
+  def var
+    reduce(0) { |a,b| a + (b - ave) ** 2 } / (size - 1)
+  end
+
+  # standard_deviation
+  def sd
+    Math.sqrt(var)
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -1,0 +1,77 @@
+require "./lib/array_extension"
+require "active_support"
+require "active_support/core_ext"
+require "json"
+require "net/http"
+require "uri"
+require "pry"
+
+# settings
+PRODUCT_CODE = "FX_BTC_JPY"
+BAND_COUNT = 20
+INTERVAL = 1.minute
+SD_LEVEL = 2
+
+# https://lightning.bitflyer.jp/docs/playground?lang=ja
+def board(product_code)
+  uri = URI.parse("https://api.bitflyer.jp")
+  uri.path = "/v1/board"
+  uri.query = "product_code=#{product_code}"
+
+  https = Net::HTTP.new(uri.host, uri.port)
+  https.use_ssl = true
+
+  response = https.get(uri.request_uri)
+  JSON.parse(response.body)
+end
+
+prices = []
+
+# BAND_COUNT ぶんの 移動平均を計算
+BAND_COUNT.times do
+  current_mid_price = board(PRODUCT_CODE)["mid_price"]
+  prices.push(current_mid_price)
+  puts "ただいまの価格は ¥#{current_mid_price.to_i.to_s(:delimited)} です。"
+  sleep(INTERVAL)
+end
+
+<<-EOS
+  "#{BAND_COUNT}" 回の平均値の集計が完了しました。
+
+  --------------------------
+  移動平均値: "#{prices.average}"
+  標準偏差(α): "#{prices.sd}"
+  --------------------------
+
+  実際の売り買いの判定処理に移ります。
+EOS
+
+# 以降の処理は BAND_COUNT 数の配列を保ちつつ、実際に売り買いの判定を行います。
+while(1)
+  current_mid_price = board(PRODUCT_CODE)["mid_price"]
+  prices.push(current_mid_price)
+  prices.shift
+
+  ave = prices.average # 移動平均
+  sd  = prices.sd # 標準偏差
+
+  <<-EOS
+    ただいまの価格は ¥"#{current_mid_price.to_i.to_s(:delimited)}" です。
+
+    --------------------------
+    移動平均値: "#{ave}"
+    標準偏差(α): "#{sd}"
+    --------------------------
+  EOS
+
+  # ボリンジャーバンドの SD_LEVEL(n 次)判定を行い、売り買いの判断を下す
+  _price = current_mid_price.to_i.to_s(:delimited)
+  if current_mid_price >= ave + SD_LEVEL * sd
+    puts "¥#{_price} で売り注文"
+  elsif current_mid_price < ave - SD_LEVEL * sd
+    puts "¥#{_price} で買い注文"
+  else
+    puts "¥#{_price} では何もしない"
+  end
+  sleep(INTERVAL)
+end


### PR DESCRIPTION
迫さん作成のサンプルコードをベースにリファクタリング。

## 残タスク
 - [ ] 動作確認

## 実行結果

```
-----20回、移動平均を計算します-----
1: ¥482,425
2: ¥482,337
3: ¥482,248
4: ¥482,076
5: ¥481,934
6: ¥481,718
7: ¥481,591
8: ¥481,549
9: ¥481,873
10: ¥481,524
11: ¥481,554
12: ¥481,559
13: ¥481,426
14: ¥481,502
15: ¥481,416
16: ¥481,500
17: ¥481,376
18: ¥481,210
19: ¥481,414
20: ¥480,931
-----------------------------

--------------------------
移動平均値: 481658.15
標準偏差(α): 382.7242067351536
--------------------------

実際の売り買いの判定処理に移ります。

.
.
.

-------------------------------
  ただいまの価格は ¥481,194 です。

  --------------------------
  移動平均値: 481596.6
  標準偏差(α): 350.53994441657983
  --------------------------
  2α のボリンジャーバンド:
  ¥480,895 〜 ¥482,297

  現在の価格: ¥481,194
  バンドの範囲内のため何もしない
-------------------------------

```